### PR TITLE
Extract initialization of GetReadyNasStats

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,26 +108,22 @@ args = arg_parser.parse_args()
 # Execute methods
 #
 
+stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
+
 if args.disks is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.process_readynas_disk_table()  # Get disk statistics
 
 if args.fans is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.process_readynas_fan_table()  # Get fan statistics
 
 if args.temp is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.process_readynas_temperature_table()  # Get temperature statistics
 
 if args.volumes is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.process_readynas_volume_table()  # Get volume statistics
 
 if args.interfaces is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.process_readynas_interface_table()  # Get interface statistics
 
 if args.uptime is True:
-    stats = GetReadyNasStats(readynas_host, readynas_snmp_community, snmp_version)  # Create a new GetReadyNasStats object
     stats.get_readynas_uptime()  # Get the device uptime


### PR DESCRIPTION
Extracting the `GetReadyNasStats` class call outside of the if-block makes the code slightly shorter and easier to read.